### PR TITLE
Fix details.json path in tests

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,10 +1,12 @@
 import sys
 import time
+import os
 
 from core.requester import requester
 from core.utils import host, load_json
 
-details = load_json(sys.path[0] + '/db/details.json')
+details_path = os.path.join(os.path.dirname(__file__), "../db/details.json")
+details = load_json(os.path.abspath(details_path))
 
 def passive_tests(url, headers):
     root = host(url)


### PR DESCRIPTION
## Summary
- load `details.json` using `os.path.join` relative to `tests.py`
- use absolute path for `load_json`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852a74a7c808322b69002b8cd3699eb