### PR TITLE
Replace fork/exec with subprocess

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,7 @@
 import os
 import json
 import tempfile
+import subprocess
 
 from urllib.parse import urlparse
 
@@ -43,21 +44,15 @@ def collect_urls(target_url=None, source=None):
     return urls
 
 def prompt(default=None):
-    editor = 'nano'
+    editor = os.environ.get('EDITOR', 'nano')
     with tempfile.NamedTemporaryFile(mode='r+') as tmpfile:
         if default:
             tmpfile.write(default)
             tmpfile.flush()
 
-        child_pid = os.fork()
-        is_child = child_pid == 0
-
-        if is_child:
-            os.execvp(editor, [editor, tmpfile.name])
-        else:
-            os.waitpid(child_pid, 0)
-            tmpfile.seek(0)
-            return tmpfile.read().strip()
+        subprocess.call([editor, tmpfile.name])
+        tmpfile.seek(0)
+        return tmpfile.read().strip()
 
 
 def extractHeaders(headers: str):


### PR DESCRIPTION
## Summary
- simplify prompt editor call
- respect `$EDITOR` environment variable

## Testing
- `python3 -m py_compile corsy.py core/*.py`
- `EDITOR=true python3 - <<'PY'
from core.utils import prompt
print(prompt('hi'))
PY`
- `EDITOR=cat python3 - <<'PY'
from core.utils import prompt
print(prompt('test123'))
PY`


------
https://chatgpt.com/codex/tasks/task_b_6852a74b6dd88322866df8b5a69abe49