### PR TITLE
Add optional preflight OPTIONS scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Using Corsy is pretty simple
 ##### Disable TLS verification
 `python3 corsy.py -u https://example.com -k`
 
+##### Use preflight OPTIONS request
+`python3 corsy.py -u https://example.com --preflight`
+
 ##### Export results to JSON
 `python3 corsy.py -i /path/urls.txt -o /path/output.json`
 

--- a/core/requester.py
+++ b/core/requester.py
@@ -9,13 +9,17 @@ session = requests.Session()
 # Added better error handling.
 # Added verbose options.
 
-def requester(url, scheme, headers, origin, timeout=10, verify=True):
+def requester(url, scheme, headers, origin, timeout=10, verify=True, method="GET"):
     """Send a request with the supplied origin and return response headers."""
     request_headers = headers.copy()
     request_headers['Origin'] = origin
     try:
-        response = session.get(
-            url, headers=request_headers, verify=verify, timeout=timeout
+        response = session.request(
+            method,
+            url,
+            headers=request_headers,
+            verify=verify,
+            timeout=timeout,
         )
         headers = response.headers
         return headers

--- a/core/tests.py
+++ b/core/tests.py
@@ -27,15 +27,25 @@ def passive_tests(url, headers):
             return {url : info}
 
 
-def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True):
+def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True, preflight=False):
+    request_headers = header_dict.copy()
+    method = "OPTIONS" if preflight else "GET"
+    if preflight:
+        request_headers['Access-Control-Request-Method'] = 'GET'
+        request_headers['Access-Control-Request-Headers'] = ', '.join(header_dict.keys())
+
     origin = scheme + '://' + root
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(
+        url, scheme, request_headers, origin, timeout=timeout, verify=verify, method=method
+    )
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header is None:
         return
     
     origin = scheme + '://' + 'example.com'
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(
+        url, scheme, request_headers, origin, timeout=timeout, verify=verify, method=method
+    )
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == (origin):
         info = details['origin reflected'].copy()
@@ -45,7 +55,9 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = scheme + '://' + root + '.example.com'
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(
+        url, scheme, request_headers, origin, timeout=timeout, verify=verify, method=method
+    )
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == (origin):
         info = details['post-domain wildcard'].copy()
@@ -55,7 +67,9 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = scheme + '://d3v' + root
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(
+        url, scheme, request_headers, origin, timeout=timeout, verify=verify, method=method
+    )
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == (origin):
         info = details['pre-domain wildcard'].copy()
@@ -65,7 +79,9 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = 'null'
-    headers = requester(url, '', header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(
+        url, '', request_headers, origin, timeout=timeout, verify=verify, method=method
+    )
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == 'null':
         info = details['null origin allowed'].copy()
@@ -75,7 +91,9 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = scheme + '://' + root + '_.example.com'
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(
+        url, scheme, request_headers, origin, timeout=timeout, verify=verify, method=method
+    )
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == origin:
         info = details['unrecognized underscore'].copy()
@@ -85,7 +103,9 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = scheme + '://' + root + '%60.example.com'
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(
+        url, scheme, request_headers, origin, timeout=timeout, verify=verify, method=method
+    )
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and '`.example.com' in acao_header:
         info = details['broken parser'].copy()
@@ -96,7 +116,9 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
 
     if root.count('.') > 1:
         origin = scheme + '://' + root.replace('.', 'x', 1)
-        headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+        headers = requester(
+            url, scheme, request_headers, origin, timeout=timeout, verify=verify, method=method
+        )
         acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
         if acao_header and acao_header == origin:
             info = details['unescaped regex'].copy()
@@ -105,7 +127,9 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
             return {url : info}
         time.sleep(delay)
     origin = 'http://' + root
-    headers = requester(url, 'http', header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(
+        url, 'http', request_headers, origin, timeout=timeout, verify=verify, method=method
+    )
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header.startswith('http://'):
         info = details['http origin allowed'].copy()


### PR DESCRIPTION
## Summary
- allow requester to use arbitrary HTTP method
- add --preflight flag to send OPTIONS request with CORS preflight headers
- pass preflight option through to active_tests
- update README with new option documentation

## Testing
- `python3 -m py_compile corsy.py core/*.py`

------
https://chatgpt.com/codex/tasks/task_b_6852a75faabc83229ba41e7c83cc1911