### PR TITLE
Fix path resolution for details.json

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,10 +1,15 @@
-import sys
+import os
 import time
 
 from core.requester import requester
 from core.utils import host, load_json
 
-details = load_json(sys.path[0] + '/db/details.json')
+details_path = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    'db',
+    'details.json',
+)
+details = load_json(details_path)
 
 def passive_tests(url, headers):
     root = host(url)


### PR DESCRIPTION
## Summary
- load `details.json` relative to project root using `os.path` utilities

## Testing
- `python3 -m py_compile core/tests.py`
- `python3 -m py_compile corsy.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6852a76134608322bff797a43fa6debd