### PR TITLE
Improve editor handling in prompt

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,7 @@
 import os
 import json
 import tempfile
+import subprocess
 
 from urllib.parse import urlparse
 
@@ -43,21 +44,20 @@ def collect_urls(target_url=None, source=None):
     return urls
 
 def prompt(default=None):
-    editor = 'nano'
-    with tempfile.NamedTemporaryFile(mode='r+') as tmpfile:
+    """Open a text editor and return the entered content.
+
+    The editor used is taken from the ``EDITOR`` environment variable if set
+    otherwise ``nano`` is used as a fallback.
+    """
+    editor = os.getenv("EDITOR", "nano")
+    with tempfile.NamedTemporaryFile(mode="r+") as tmpfile:
         if default:
             tmpfile.write(default)
             tmpfile.flush()
 
-        child_pid = os.fork()
-        is_child = child_pid == 0
-
-        if is_child:
-            os.execvp(editor, [editor, tmpfile.name])
-        else:
-            os.waitpid(child_pid, 0)
-            tmpfile.seek(0)
-            return tmpfile.read().strip()
+        subprocess.run([editor, tmpfile.name])
+        tmpfile.seek(0)
+        return tmpfile.read().strip()
 
 
 def extractHeaders(headers: str):


### PR DESCRIPTION
## Summary
- read `$EDITOR` in `core/utils.prompt`
- use `subprocess.run` instead of `os.fork`/`execvp`

## Testing
- `python3 -m py_compile corsy.py core/*.py`
- `python3 corsy.py -h | head`

------
https://chatgpt.com/codex/tasks/task_b_6852a7618f188322a83c48efa8182e8f