### PR TITLE
Add asyncio scanning mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Corsy is a lightweight program that scans for all known misconfigurations in COR
 ![demo](https://i.ibb.co/Jc1HtmW/corsy.png)
 
 ### Requirements
-Corsy only works with `Python 3` and has just one dependency:
+Corsy only works with `Python 3` and requires:
 
 - `requests`
+- `aiohttp` (for async mode)
 
-To install this dependency, navigate to Corsy directory and execute `pip3 install requests`
+Install dependencies with `pip3 install -r requirements.txt`
 
 ### Usage
 Using Corsy is pretty simple
@@ -52,6 +53,9 @@ Using Corsy is pretty simple
 
 ##### Disable TLS verification
 `python3 corsy.py -u https://example.com -k`
+
+##### Async scanning mode
+`python3 corsy.py -u https://example.com --mode async`
 
 ##### Export results to JSON
 `python3 corsy.py -i /path/urls.txt -o /path/output.json`

--- a/core/requester.py
+++ b/core/requester.py
@@ -1,5 +1,6 @@
 import urllib3
 import requests
+import aiohttp
 from core.colors import bad
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -21,6 +22,23 @@ def requester(url, scheme, headers, origin, timeout=10, verify=True):
         return headers
     except requests.exceptions.RequestException as e:
         if 'Failed to establish a new connection' in str(e):
+            print('%s %s is unreachable' % (bad, url))
+        elif 'TooManyRedirects' in str(e):
+            print('%s %s has too many redirects' % (bad, url))
+        return {}
+
+
+async def requester_async(url, scheme, headers, origin, timeout=10, verify=True):
+    """Asynchronous version of requester using aiohttp."""
+    request_headers = headers.copy()
+    request_headers['Origin'] = origin
+    timeout_obj = aiohttp.ClientTimeout(total=timeout)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout_obj) as session:
+            async with session.get(url, headers=request_headers, ssl=verify) as response:
+                return response.headers
+    except aiohttp.ClientError as e:
+        if 'Failed to establish a new connection' in str(e) or 'ClientConnectorError' in str(e):
             print('%s %s is unreachable' % (bad, url))
         elif 'TooManyRedirects' in str(e):
             print('%s %s has too many redirects' % (bad, url))

--- a/corsy.py
+++ b/corsy.py
@@ -4,9 +4,10 @@
 import sys
 import json
 import argparse
+import asyncio
 from requests.exceptions import ConnectionError
 
-from core.tests import active_tests
+from core.tests import active_tests, active_tests_async
 from core.utils import host, prompt, format_result, extractHeaders, collect_urls
 from core.colors import bad, end, red, run, good, grey, green, white, yellow
 
@@ -35,6 +36,7 @@ def main():
     parser.add_argument('--headers', help='add headers', dest='header_dict', nargs='?', const=True)
     parser.add_argument('--timeout', help='request timeout', dest='timeout', type=float, default=10)
     parser.add_argument('-k', '--insecure', help='disable TLS verification', dest='insecure', action='store_true')
+    parser.add_argument('--mode', choices=['threaded', 'async'], default='threaded', help='scanning mode')
     args = parser.parse_args()
 
     delay = args.delay
@@ -46,6 +48,7 @@ def main():
     header_dict = args.header_dict
     timeout = args.timeout
     verify_cert = not args.insecure
+    mode = args.mode
 
     if type(header_dict) == bool:
         header_dict = extractHeaders(prompt())
@@ -85,28 +88,62 @@ def main():
         except ConnectionError:
             print('%s Unable to connect to %s' % (bad, root))
 
+    async def cors_async(target, header_dict, delay, timeout, verify):
+        url = target
+        root = host(url)
+        parsed = urlparse(url)
+        netloc = parsed.netloc
+        scheme = parsed.scheme
+        url = scheme + '://' + netloc + parsed.path
+        try:
+            return await active_tests_async(url, root, scheme, header_dict, delay, timeout=timeout, verify=verify)
+        except ConnectionError:
+            print('%s Unable to connect to %s' % (bad, root))
+
     if urls:
         if len(urls) > 1:
             print(' %s Estimated scan time: %i secs' % (run, round(len(urls) * 1.75)))
         results = []
-        threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
-        futures = (
-            threadpool.submit(cors, url, header_dict, delay, timeout, verify_cert)
-            for url in urls
-        )
-        for each in concurrent.futures.as_completed(futures):
-            result = each.result()
-            results.append(result)
-            if result:
-                for i in result:
-                    print(' %s %s' % (good, i))
-                    print('   %s-%s Class: %s' % (yellow, end, result[i]['class']))
-                    if not quiet:
-                        print('   %s-%s Description: %s' % (yellow, end, result[i]['description']))
-                        print('   %s-%s Severity: %s' % (yellow, end, result[i]['severity']))
-                        print('   %s-%s Exploitation: %s' % (yellow, end, result[i]['exploitation']))
-                    print('   %s-%s ACAO Header: %s' % (yellow, end, result[i]['acao header']))
-                    print('   %s-%s ACAC Header: %s\n' % (yellow, end, result[i]['acac header']))
+        if mode == 'threaded':
+            threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
+            futures = (
+                threadpool.submit(cors, url, header_dict, delay, timeout, verify_cert)
+                for url in urls
+            )
+            for each in concurrent.futures.as_completed(futures):
+                result = each.result()
+                results.append(result)
+                if result:
+                    for i in result:
+                        print(' %s %s' % (good, i))
+                        print('   %s-%s Class: %s' % (yellow, end, result[i]['class']))
+                        if not quiet:
+                            print('   %s-%s Description: %s' % (yellow, end, result[i]['description']))
+                            print('   %s-%s Severity: %s' % (yellow, end, result[i]['severity']))
+                            print('   %s-%s Exploitation: %s' % (yellow, end, result[i]['exploitation']))
+                        print('   %s-%s ACAO Header: %s' % (yellow, end, result[i]['acao header']))
+                        print('   %s-%s ACAC Header: %s\n' % (yellow, end, result[i]['acac header']))
+        else:
+            async def runner():
+                sem = asyncio.Semaphore(threads)
+                async def bound(url):
+                    async with sem:
+                        return await cors_async(url, header_dict, delay, timeout, verify_cert)
+                tasks = [asyncio.create_task(bound(url)) for url in urls]
+                for task in asyncio.as_completed(tasks):
+                    result = await task
+                    results.append(result)
+                    if result:
+                        for i in result:
+                            print(' %s %s' % (good, i))
+                            print('   %s-%s Class: %s' % (yellow, end, result[i]['class']))
+                            if not quiet:
+                                print('   %s-%s Description: %s' % (yellow, end, result[i]['description']))
+                                print('   %s-%s Severity: %s' % (yellow, end, result[i]['severity']))
+                                print('   %s-%s Exploitation: %s' % (yellow, end, result[i]['exploitation']))
+                            print('   %s-%s ACAO Header: %s' % (yellow, end, result[i]['acao header']))
+                            print('   %s-%s ACAC Header: %s\n' % (yellow, end, result[i]['acac header']))
+            asyncio.run(runner())
         results = format_result(results)
         if results:
             if json_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+aiohttp


### PR DESCRIPTION
## Summary
- add async requester using aiohttp
- implement `active_tests_async`
- support `--mode` CLI option for threaded or async scanning
- document requirements and async usage

## Testing
- `python3 -m py_compile corsy.py core/*.py`
- `python3 corsy.py --help`
- `python3 corsy.py -u https://example.com --mode async --timeout 1`
- `python3 corsy.py -u https://example.com --timeout 1`


------
https://chatgpt.com/codex/tasks/task_b_6852a7628e448322817a71b816f1491c