### PR TITLE
Handle malformed headers gracefully

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,7 +1,11 @@
 import sys
 import time
 
-from core.requester import requester
+try:
+    from core.requester import requester  # requires requests/urllib3
+except Exception:
+    requester = None
+
 from core.utils import host, load_json
 
 details = load_json(sys.path[0] + '/db/details.json')

--- a/core/utils.py
+++ b/core/utils.py
@@ -60,9 +60,24 @@ def prompt(default=None):
             return tmpfile.read().strip()
 
 
-def extractHeaders(headers: str):
+def extractHeaders(headers: str, warn: bool = False):
+    """Parse a header string into a dictionary.
+
+    Blank lines and lines missing a ``:`` are ignored. If ``warn`` is ``True``
+    a warning is printed for every ignored malformed line.
+    """
+
     sorted_headers = {}
-    for header in headers.split('\\n'):
+    for header in headers.split('\n'):
+        header = header.strip()
+        if not header:
+            continue
+
+        if ':' not in header:
+            if warn:
+                print(f"Warning: ignoring malformed header '{header}'")
+            continue
+
         name, value = header.split(":", 1)
         name = name.strip()
         value = value.strip()

--- a/corsy.py
+++ b/corsy.py
@@ -48,9 +48,9 @@ def main():
     verify_cert = not args.insecure
 
     if type(header_dict) == bool:
-        header_dict = extractHeaders(prompt())
+        header_dict = extractHeaders(prompt(), warn=True)
     elif type(header_dict) == str:
-        header_dict = extractHeaders(header_dict)
+        header_dict = extractHeaders(header_dict, warn=True)
     else:
         header_dict = {
             'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:70.0) Gecko/20100101 Firefox/70.0',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import patch
+
+from core.utils import extractHeaders
+
+
+class TestExtractHeaders(unittest.TestCase):
+    def test_valid_headers(self):
+        headers = "User-Agent: UA\nAccept: text/html\n"
+        expected = {"User-Agent": "UA", "Accept": "text/html"}
+        self.assertEqual(extractHeaders(headers), expected)
+
+    def test_ignores_blank_and_missing_colon(self):
+        headers = "User-Agent: UA\n\nInvalidLine\nAccept: text/html"
+        expected = {"User-Agent": "UA", "Accept": "text/html"}
+        self.assertEqual(extractHeaders(headers), expected)
+
+    def test_warning_on_malformed(self):
+        headers = "Header: value\nMalformed"
+        with patch('builtins.print') as mock_print:
+            result = extractHeaders(headers, warn=True)
+            self.assertEqual(result, {"Header": "value"})
+            mock_print.assert_called_once()
+            self.assertIn('Malformed', mock_print.call_args[0][0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- tolerate blank or malformed header lines when parsing
- alert the user about ignored malformed headers
- adjust CLI to enable warnings
- make `core.tests` import safe when dependencies are missing
- add unit tests for `extractHeaders`

## Testing
- `python -m unittest discover -v tests`


------
https://chatgpt.com/codex/tasks/task_b_6852a775b64c8322983706b7ac5dd48b