### PR TITLE
Use EDITOR env variable for header prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Using Corsy is pretty simple
 ##### Custom HTTP headers
 `python3 corsy.py -u https://example.com --headers "User-Agent: GoogleBot\nCookie: SESSION=Hacked"`
 
+Running `--headers` without a value opens your editor for interactive entry. The
+program uses the `EDITOR` environment variable or defaults to `nano`.
+
 ##### Skip printing tips
 `-q` can be used to skip printing of `description`, `severity`, `exploitation` fields in the output.
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,7 @@
 import os
 import json
 import tempfile
+import subprocess
 
 from urllib.parse import urlparse
 
@@ -43,21 +44,15 @@ def collect_urls(target_url=None, source=None):
     return urls
 
 def prompt(default=None):
-    editor = 'nano'
+    editor = os.environ.get('EDITOR', 'nano')
     with tempfile.NamedTemporaryFile(mode='r+') as tmpfile:
         if default:
             tmpfile.write(default)
             tmpfile.flush()
 
-        child_pid = os.fork()
-        is_child = child_pid == 0
-
-        if is_child:
-            os.execvp(editor, [editor, tmpfile.name])
-        else:
-            os.waitpid(child_pid, 0)
-            tmpfile.seek(0)
-            return tmpfile.read().strip()
+        subprocess.call([editor, tmpfile.name])
+        tmpfile.seek(0)
+        return tmpfile.read().strip()
 
 
 def extractHeaders(headers: str):


### PR DESCRIPTION
## Summary
- let header input use `$EDITOR` with `nano` fallback
- replace fork/exec logic with `subprocess.call`
- document editor behavior in README

## Testing
- `python3 -m py_compile corsy.py core/*.py`

------
https://chatgpt.com/codex/tasks/task_b_6852a7776c848322b7312e1b1d98b451