### PR TITLE
Fix resource path

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,10 +1,13 @@
 import sys
 import time
+from pathlib import Path
 
 from core.requester import requester
 from core.utils import host, load_json
 
-details = load_json(sys.path[0] + '/db/details.json')
+# Load vulnerability descriptions from the db directory relative to this file
+details_path = Path(__file__).resolve().parents[1] / 'db' / 'details.json'
+details = load_json(details_path)
 
 def passive_tests(url, headers):
     root = host(url)


### PR DESCRIPTION
## Summary
- use a path relative to tests.py so details.json is found when installed

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6852a77b4f448322a8ff1bdaabee4922