### PR TITLE
Remove unused scheme arg in requester

### DIFF
--- a/core/requester.py
+++ b/core/requester.py
@@ -9,7 +9,7 @@ session = requests.Session()
 # Added better error handling.
 # Added verbose options.
 
-def requester(url, scheme, headers, origin, timeout=10, verify=True):
+def requester(url, headers, origin, timeout=10, verify=True):
     """Send a request with the supplied origin and return response headers."""
     request_headers = headers.copy()
     request_headers['Origin'] = origin

--- a/core/tests.py
+++ b/core/tests.py
@@ -29,13 +29,13 @@ def passive_tests(url, headers):
 
 def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True):
     origin = scheme + '://' + root
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header is None:
         return
     
     origin = scheme + '://' + 'example.com'
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == (origin):
         info = details['origin reflected'].copy()
@@ -45,7 +45,7 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = scheme + '://' + root + '.example.com'
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == (origin):
         info = details['post-domain wildcard'].copy()
@@ -55,7 +55,7 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = scheme + '://d3v' + root
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == (origin):
         info = details['pre-domain wildcard'].copy()
@@ -65,7 +65,7 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = 'null'
-    headers = requester(url, '', header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == 'null':
         info = details['null origin allowed'].copy()
@@ -75,7 +75,7 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = scheme + '://' + root + '_.example.com'
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header == origin:
         info = details['unrecognized underscore'].copy()
@@ -85,7 +85,7 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
     time.sleep(delay)
 
     origin = scheme + '://' + root + '%60.example.com'
-    headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and '`.example.com' in acao_header:
         info = details['broken parser'].copy()
@@ -96,7 +96,7 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
 
     if root.count('.') > 1:
         origin = scheme + '://' + root.replace('.', 'x', 1)
-        headers = requester(url, scheme, header_dict, origin, timeout=timeout, verify=verify)
+        headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
         acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
         if acao_header and acao_header == origin:
             info = details['unescaped regex'].copy()
@@ -105,7 +105,7 @@ def active_tests(url, root, scheme, header_dict, delay, timeout=10, verify=True)
             return {url : info}
         time.sleep(delay)
     origin = 'http://' + root
-    headers = requester(url, 'http', header_dict, origin, timeout=timeout, verify=verify)
+    headers = requester(url, header_dict, origin, timeout=timeout, verify=verify)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header and acao_header.startswith('http://'):
         info = details['http origin allowed'].copy()


### PR DESCRIPTION
## Summary
- simplify `requester()` API by removing unused `scheme` argument
- update all calls in tests

## Testing
- `python3 -m compileall -q core/requester.py core/tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6852a7919dd483228fa93fda0488c56c