### PR TITLE
Improve header parsing and add tests

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -61,9 +61,20 @@ def prompt(default=None):
 
 
 def extractHeaders(headers: str):
+    """Return headers parsed into a dictionary.
+
+    Lines without a ``:`` separator are ignored with a warning instead of
+    raising an exception.
+    """
     sorted_headers = {}
-    for header in headers.split('\\n'):
-        name, value = header.split(":", 1)
+    for header in headers.split('\n'):
+        header = header.strip()
+        if not header:
+            continue
+        if ':' not in header:
+            print(f"Skipping invalid header line: {header}")
+            continue
+        name, value = header.split(':', 1)
         name = name.strip()
         value = value.strip()
         if len(value) >= 1 and value[-1] == ',':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.utils import extractHeaders
+
+
+def test_extract_headers_valid():
+    headers = "Host: example.com\nContent-Type: text/html"
+    assert extractHeaders(headers) == {
+        "Host": "example.com",
+        "Content-Type": "text/html",
+    }
+
+
+def test_extract_headers_invalid_lines_are_skipped(capfd):
+    headers = "InvalidLine\nAccept: */*\nAnotherInvalid"
+    result = extractHeaders(headers)
+    out, _ = capfd.readouterr()
+    assert "Skipping invalid header line: InvalidLine" in out
+    assert "Skipping invalid header line: AnotherInvalid" in out
+    assert result == {"Accept": "*/*"}


### PR DESCRIPTION
## Summary
- ignore invalid header lines in `extractHeaders`
- add unit tests for `extractHeaders`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852a794771083228fec10f90e6a43d9